### PR TITLE
Add ability to supply invocation timeout override

### DIFF
--- a/src/main/scala/io/toolebox/gatlinglambdaextension/protocol/LambdaProtocol.scala
+++ b/src/main/scala/io/toolebox/gatlinglambdaextension/protocol/LambdaProtocol.scala
@@ -1,5 +1,7 @@
 package io.toolebox.gatlinglambdaextension.protocol
 
+import java.time.Duration
+
 import io.gatling.core.protocol.{Protocol, ProtocolKey}
 
 object LambdaProtocol {
@@ -11,6 +13,7 @@ case class LambdaProtocol(
     awsAccessKeyId: Option[String],
     awsSecretAccessKey: Option[String],
     awsSessionToken: Option[String],
+    timeout: Option[Duration],
     endpoint: Option[String],
     region: Option[String]
 ) extends Protocol {}

--- a/src/main/scala/io/toolebox/gatlinglambdaextension/protocol/LambdaProtocolBuilder.scala
+++ b/src/main/scala/io/toolebox/gatlinglambdaextension/protocol/LambdaProtocolBuilder.scala
@@ -1,9 +1,12 @@
 package io.toolebox.gatlinglambdaextension.protocol
 
+import java.time.Duration
+
 case class LambdaProtocolBuilder(
     awsAccessKeyId: Option[String] = None,
     awsSecretAccessKey: Option[String] = None,
     awsSessionToken: Option[String] = None,
+    timeout: Option[Duration] = None,
     endpoint: Option[String] = None,
     region: Option[String] = None
 ) {
@@ -13,6 +16,8 @@ case class LambdaProtocolBuilder(
     copy(awsSecretAccessKey = Some(key))
   def sessionToken(token: String): LambdaProtocolBuilder =
     copy(awsSessionToken = Some(token))
+  def timeout(duration: Duration): LambdaProtocolBuilder =
+    copy(timeout = Some(duration))
   def endpoint(url: String): LambdaProtocolBuilder =
     copy(endpoint = Some(url))
   def region(region: String): LambdaProtocolBuilder =
@@ -22,6 +27,7 @@ case class LambdaProtocolBuilder(
       awsAccessKeyId,
       awsSecretAccessKey,
       awsSessionToken,
+      timeout,
       endpoint,
       region
     )


### PR DESCRIPTION
The default override is not long enough for long-lived lambda functions.

This change allows clients to override the timeout to be longer (or
shorter).

The timeout is currently applied to both the apiCallTimeout and the
apiCallAttemptTimeout, which probably isn't the intended way for it
to work but worst case scenario I can just provide two new methods
and deprecate this one if it causes any problems.