### PR TITLE
Gatling 3.5.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,13 @@ java {
     withJavadocJar()
 }
 
+versioner {
+    startFrom {
+        major = 3
+        minor = 2
+    }
+}
+
 publishing {
     publications {
         create<MavenPublication>("mavenJava") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,9 @@ versioner {
         major = 3
         minor = 2
     }
+    tag {
+        useCommitMessage = true
+    }
 }
 
 publishing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,8 +16,8 @@ repositories {
 }
 
 dependencies {
-    implementation("org.scala-lang:scala-library:2.12.10")
-    implementation("io.gatling:gatling-core:3.3.1")
+    implementation("org.scala-lang:scala-library:2.13.4")
+    implementation("io.gatling:gatling-core:3.5.0")
     implementation("software.amazon.awssdk:lambda:2.10.50")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,10 +3,10 @@ import java.util.Base64
 plugins {
     scala
     signing
-    id("com.diffplug.spotless") version "5.8.1"
-    id("io.toolebox.git-versioner") version "1.6.5"
-    id("io.codearte.nexus-staging") version "0.22.0"
-    id("de.marcphilipp.nexus-publish") version "0.4.0"
+    id("com.diffplug.spotless") version Versions.spotless
+    id("io.toolebox.git-versioner") version Versions.versioner
+    id("io.codearte.nexus-staging") version Versions.nexusStaging
+    id("de.marcphilipp.nexus-publish") version Versions.nexusPublish
 }
 
 group = "io.toolebox"
@@ -16,9 +16,9 @@ repositories {
 }
 
 dependencies {
-    implementation("org.scala-lang:scala-library:2.13.4")
-    implementation("io.gatling:gatling-core:3.5.0")
-    implementation("software.amazon.awssdk:lambda:2.10.50")
+    implementation("org.scala-lang:scala-library:${Versions.scala}")
+    implementation("io.gatling:gatling-core:${Versions.gatling}")
+    implementation("software.amazon.awssdk:lambda:${Versions.awsSdk}")
 }
 
 spotless {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,0 +1,9 @@
+object Versions {
+        const val awsSdk = "2.15.78" // https://search.maven.org/artifact/software.amazon.awssdk/bom
+        const val gatling = "3.5.0" // https://search.maven.org/artifact/io.gatling/gatling-core
+        const val nexusPublish = "0.4.0" // https://plugins.gradle.org/plugin/de.marcphilipp.nexus-publish
+        const val nexusStaging = "0.22.0" // https://plugins.gradle.org/plugin/io.codearte.nexus-staging
+        const val scala = "2.13.4" // https://search.maven.org/artifact/org.scala-lang/scala-library
+        const val spotless = "5.9.0" // https://plugins.gradle.org/plugin/com.diffplug.gradle.spotless
+        const val versioner = "1.6.5" // https://plugins.gradle.org/plugin/io.toolebox.git-versioner
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/scala/io/toolebox/gatlinglambdaextension/Predef.scala
+++ b/src/main/scala/io/toolebox/gatlinglambdaextension/Predef.scala
@@ -1,5 +1,6 @@
 package io.toolebox.gatlinglambdaextension
 
+import scala.language.implicitConversions
 import io.gatling.core.action.builder.ActionBuilder
 import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.session.Expression

--- a/src/main/scala/io/toolebox/gatlinglambdaextension/action/InvokeAction.scala
+++ b/src/main/scala/io/toolebox/gatlinglambdaextension/action/InvokeAction.scala
@@ -71,7 +71,16 @@ class InvokeAction(
   override def clock: Clock = coreComponents.clock
 
   private def logSuccess(session: Session, start: Long, end: Long) {
-    statsEngine.logResponse(session, name, start, end, OK, None, None)
+    statsEngine.logResponse(
+      session.scenario,
+      session.groups,
+      name,
+      start,
+      end,
+      OK,
+      None,
+      None
+    )
     next ! session.markAsSucceeded
   }
 
@@ -81,7 +90,16 @@ class InvokeAction(
       end: Long,
       message: String
   ) {
-    statsEngine.logResponse(session, name, start, end, KO, None, Some(message))
+    statsEngine.logResponse(
+      session.scenario,
+      session.groups,
+      name,
+      start,
+      end,
+      KO,
+      None,
+      Some(message)
+    )
     next ! session.markAsFailed
   }
 

--- a/src/main/scala/io/toolebox/gatlinglambdaextension/action/InvokeAction.scala
+++ b/src/main/scala/io/toolebox/gatlinglambdaextension/action/InvokeAction.scala
@@ -70,7 +70,7 @@ class InvokeAction(
 
   override def clock: Clock = coreComponents.clock
 
-  private def logSuccess(session: Session, start: Long, end: Long) {
+  private def logSuccess(session: Session, start: Long, end: Long): Unit = {
     statsEngine.logResponse(
       session.scenario,
       session.groups,
@@ -89,7 +89,7 @@ class InvokeAction(
       start: Long,
       end: Long,
       message: String
-  ) {
+  ): Unit = {
     statsEngine.logResponse(
       session.scenario,
       session.groups,

--- a/src/main/scala/io/toolebox/gatlinglambdaextension/protocol/LambdaComponents.scala
+++ b/src/main/scala/io/toolebox/gatlinglambdaextension/protocol/LambdaComponents.scala
@@ -8,7 +8,7 @@ case class LambdaComponents(
     coreComponents: CoreComponents,
     lambdaProtocol: LambdaProtocol
 ) extends ProtocolComponents {
-  override def onStart: Session => Session = ProtocolComponents.NoopOnStart
+  override def onStart: Session => Session = Session.Identity
 
   override def onExit: Session => Unit = ProtocolComponents.NoopOnExit
 }


### PR DESCRIPTION
Update to Gatling 3.5.0 and Scala 2.13

Updates versioning configuration to match Gatling versions, to allow consumers to more easily pick the correct version in future.

General fixes and updates.

Closes #12