### PR TITLE
Enable reproducible builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,3 +92,8 @@ nexusPublishing {
         sonatype()
     }
 }
+
+tasks.withType<AbstractArchiveTask>() {
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+}


### PR DESCRIPTION
To ensure that this project can be correctly reproduced by an
independent build of the project, we should enable reproducible builds
in Gradle, across all projects.
